### PR TITLE
Создать .env файл на VM при деплое из GitHub Environment secrets

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -61,8 +61,24 @@ jobs:
 
             cd /opt/edium
 
-            # Выставляем тег
-            export IMAGE_TAG=${{ inputs.image_tag }}
+            # Создание .env из секретов
+            cat > .env <<'ENVEOF'
+            YC_REGISTRY_ID=${{ secrets.YC_REGISTRY_ID }}
+            IMAGE_TAG=${{ inputs.image_tag }}
+            DOORMAN_PG_USER=${{ secrets.DOORMAN_PG_USER }}
+            DOORMAN_PG_PWD=${{ secrets.DOORMAN_PG_PWD }}
+            DOORMAN_PG_DB=${{ secrets.DOORMAN_PG_DB }}
+            PG_HOST=${{ secrets.PG_HOST }}
+            DOORMAN_REDIS_PWD=${{ secrets.DOORMAN_REDIS_PWD }}
+            REDIS_HOST=${{ secrets.REDIS_HOST }}
+            JWT_ACTIVE_KID=${{ secrets.JWT_ACTIVE_KID }}
+            ENVEOF
+            sed -i 's/^[[:space:]]*//' .env
+
+            # RSA-ключ: многострочный PEM → одна строка с \n
+            printf 'JWT_RSA_PRIVATE_KEY=' >> .env
+            printf '%s' '${{ secrets.JWT_RSA_PRIVATE_KEY }}' | awk 'NR>1{printf "\\n"}{printf "%s",$0}' >> .env
+            echo >> .env
 
             # Авторизация в CR
             echo '${{ secrets.YC_SA_KEY_JSON }}' | docker login --username json_key --password-stdin cr.yandex

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -116,6 +116,24 @@ jobs:
 
             cd /opt/edium
 
+            # Создание .env из секретов
+            cat > .env <<'ENVEOF'
+            YC_REGISTRY_ID=${{ secrets.YC_REGISTRY_ID }}
+            DOORMAN_PG_USER=${{ secrets.DOORMAN_PG_USER }}
+            DOORMAN_PG_PWD=${{ secrets.DOORMAN_PG_PWD }}
+            DOORMAN_PG_DB=${{ secrets.DOORMAN_PG_DB }}
+            PG_HOST=${{ secrets.PG_HOST }}
+            DOORMAN_REDIS_PWD=${{ secrets.DOORMAN_REDIS_PWD }}
+            REDIS_HOST=${{ secrets.REDIS_HOST }}
+            JWT_ACTIVE_KID=${{ secrets.JWT_ACTIVE_KID }}
+            ENVEOF
+            sed -i 's/^[[:space:]]*//' .env
+
+            # RSA-ключ: многострочный PEM → одна строка с \n
+            printf 'JWT_RSA_PRIVATE_KEY=' >> .env
+            printf '%s' '${{ secrets.JWT_RSA_PRIVATE_KEY }}' | awk 'NR>1{printf "\\n"}{printf "%s",$0}' >> .env
+            echo >> .env
+
             # Авторизация в CR
             echo '${{ secrets.YC_SA_KEY_JSON }}' | docker login --username json_key --password-stdin cr.yandex
 


### PR DESCRIPTION
Docker Compose на VM не видел переменные окружения (YC_REGISTRY_ID, PG_HOST и др.), потому что .env не существовал. Теперь deploy-шаг пишет .env из секретов перед запуском. RSA-ключ конвертируется из многострочного PEM в однострочный с \n.