### PR TITLE
Исправить search_path в V002 миграции

### DIFF
--- a/doorman/migrations/V002__task.sql
+++ b/doorman/migrations/V002__task.sql
@@ -1,3 +1,5 @@
+SET search_path TO doorman;
+
 CREATE TYPE task_status AS ENUM (
     'pending',
     'processing',


### PR DESCRIPTION
## Summary
- V002__task.sql падал: `function set_updated_at() does not exist`
- Причина: функция создана в схеме `doorman` (V001), а V002 работал в `public`
- Фикс: добавлен `SET search_path TO doorman;` в начало V002

## Test plan
- [ ] Flyway успешно применяет V002 после мержа и деплоя