### PR TITLE
fix: исправить порт Redis с 6380 на 6379

### DIFF
--- a/infra/compose/prod/docker-compose.yml
+++ b/infra/compose/prod/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       APP_PORT: "80"
       POSTGRES_DSN: "postgres://${DOORMAN_PG_USER}:${DOORMAN_PG_PWD}@${PG_HOST}:6432/${DOORMAN_PG_DB}?sslmode=require"
-      REDIS_URL: "redis://:${DOORMAN_REDIS_PWD}@${REDIS_HOST}:6380/0"
+      REDIS_URL: "redis://:${DOORMAN_REDIS_PWD}@${REDIS_HOST}:6379/0"
       NATS_URL: "nats://nats:4222"
       JWT_RSA_PRIVATE_KEY: ${JWT_RSA_PRIVATE_KEY}
       JWT_ACTIVE_KID: ${JWT_ACTIVE_KID:-key-1}

--- a/infra/compose/test/docker-compose.yml
+++ b/infra/compose/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       APP_PORT: "80"
       POSTGRES_DSN: "postgres://${DOORMAN_PG_USER}:${DOORMAN_PG_PWD}@${PG_HOST}:6432/${DOORMAN_PG_DB}?sslmode=require"
-      REDIS_URL: "redis://:${DOORMAN_REDIS_PWD}@${REDIS_HOST}:6380/0"
+      REDIS_URL: "redis://:${DOORMAN_REDIS_PWD}@${REDIS_HOST}:6379/0"
       NATS_URL: "nats://nats:4222"
       JWT_RSA_PRIVATE_KEY: ${JWT_RSA_PRIVATE_KEY}
       JWT_ACTIVE_KID: ${JWT_ACTIVE_KID:-key-1}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -65,7 +65,7 @@ resource "yandex_vpc_security_group" "db" {
   ingress {
     description    = "Redis"
     protocol       = "TCP"
-    port           = 6380
+    port           = 6379
     v4_cidr_blocks = [for s in yandex_vpc_subnet.this : s.v4_cidr_blocks[0]]
   }
 


### PR DESCRIPTION
Managed Redis без TLS слушает на 6379, а не 6380