### PR TITLE
feat: добавить Caddyfile для test и prod окружений

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,7 +41,7 @@ jobs:
           host: ${{ secrets.PROD_VM_HOST }}
           username: deploy
           key: ${{ secrets.PROD_VM_SSH_KEY }}
-          source: "infra/compose/prod/docker-compose.yml,infra/caddy/Caddyfile.prod,doorman/migrations/,herald/migrations/"
+          source: "infra/compose/prod/docker-compose.yml,infra/compose/prod/Caddyfile,doorman/migrations/,herald/migrations/"
           target: /tmp/edium-deploy/
           strip_components: 0
 
@@ -56,7 +56,7 @@ jobs:
 
             # Подготовка файлов
             cp /tmp/edium-deploy/infra/compose/prod/docker-compose.yml /opt/edium/docker-compose.yml
-            cp /tmp/edium-deploy/infra/caddy/Caddyfile.prod /opt/edium/Caddyfile
+            cp /tmp/edium-deploy/infra/compose/prod/Caddyfile /opt/edium/Caddyfile
             mkdir -p /opt/edium/migrations/doorman /opt/edium/migrations/herald
             cp -r /tmp/edium-deploy/doorman/migrations/* /opt/edium/migrations/doorman/
             cp -r /tmp/edium-deploy/herald/migrations/* /opt/edium/migrations/herald/

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -121,7 +121,7 @@ jobs:
           host: ${{ secrets.TEST_VM_HOST }}
           username: deploy
           key: ${{ secrets.TEST_VM_SSH_KEY }}
-          source: "infra/compose/test/docker-compose.yml,infra/caddy/Caddyfile.test,doorman/migrations/,herald/migrations/"
+          source: "infra/compose/test/docker-compose.yml,infra/compose/test/Caddyfile,doorman/migrations/,herald/migrations/"
           target: /tmp/edium-deploy/
           strip_components: 0
 
@@ -136,7 +136,7 @@ jobs:
 
             # Подготовка файлов
             cp /tmp/edium-deploy/infra/compose/test/docker-compose.yml /opt/edium/docker-compose.yml
-            cp /tmp/edium-deploy/infra/caddy/Caddyfile.test /opt/edium/Caddyfile
+            cp /tmp/edium-deploy/infra/compose/test/Caddyfile /opt/edium/Caddyfile
             mkdir -p /opt/edium/migrations/doorman /opt/edium/migrations/herald
             cp -r /tmp/edium-deploy/doorman/migrations/* /opt/edium/migrations/doorman/
             cp -r /tmp/edium-deploy/herald/migrations/* /opt/edium/migrations/herald/

--- a/infra/compose/prod/Caddyfile
+++ b/infra/compose/prod/Caddyfile
@@ -1,0 +1,3 @@
+api.edium.online {
+    reverse_proxy doorman:80
+}

--- a/infra/compose/test/Caddyfile
+++ b/infra/compose/test/Caddyfile
@@ -1,0 +1,3 @@
+test.edium.online {
+    reverse_proxy doorman:80
+}


### PR DESCRIPTION
Caddy роутит test.edium.online → doorman (test)
и api.edium.online → doorman (prod).
