### PR TITLE
Riddler: JetStream-публикация riddler.generation.requested

### DIFF
--- a/riddler/internal/app/app.go
+++ b/riddler/internal/app/app.go
@@ -61,6 +61,14 @@ func New(ctx context.Context, cfg *config.Config) (*App, error) {
 		return nil, err
 	}
 
+	js, err := natsConn.JetStream()
+	if err != nil {
+		return nil, fmt.Errorf("jetstream: %w", err)
+	}
+	if err := natsinf.EnsureGenerationStream(js); err != nil {
+		return nil, fmt.Errorf("ensure generation stream: %w", err)
+	}
+
 	jwksClient := jwks.NewClient(cfg.Doorman.JWKSEndpoint)
 	if err := jwksClient.Load(ctx); err != nil {
 		return nil, fmt.Errorf("загрузка JWKS: %w", err)
@@ -82,6 +90,7 @@ func New(ctx context.Context, cfg *config.Config) (*App, error) {
 	attemptHandler := attempthandler.NewHandler(attemptService)
 
 	natsPublisher := natsinf.NewPublisher(natsConn)
+	natsJSPublisher := natsinf.NewJetStreamPublisher(js)
 	natsSubscriber := natsinf.NewSubscriber(natsConn)
 
 	return &App{
@@ -94,7 +103,7 @@ func New(ctx context.Context, cfg *config.Config) (*App, error) {
 		attemptCreatedPublisher:       worker.NewAttemptCreatedPublisher(taskRepo, natsPublisher),
 		attemptScoredPublisher:        worker.NewAttemptScoredPublisher(taskRepo, natsPublisher),
 
-		generationRequestedPublisher:  worker.NewGenerationRequestedPublisher(taskRepo, natsPublisher),
+		generationRequestedPublisher:  worker.NewGenerationRequestedPublisher(taskRepo, natsJSPublisher),
 		generationCompletedConsumer:   worker.NewGenerationCompletedConsumer(natsSubscriber, taskRepo),
 		generationCompletedProcessor:  worker.NewGenerationCompletedProcessor(taskRepo, quizService),
 		courseSessionDeletedConsumer:  worker.NewCourseSessionDeletedConsumer(natsSubscriber, taskRepo),

--- a/riddler/internal/infra/nats/publisher.go
+++ b/riddler/internal/infra/nats/publisher.go
@@ -41,3 +41,26 @@ func (p *Publisher) Publish(ctx context.Context, subject string, data []byte) er
 	}
 	return nil
 }
+
+// JetStreamPublisher публикует через JetStream и получает server-side ack о записи в стрим.
+// Используется для субъектов, где важна гарантия доставки (например, riddler → sphinx).
+type JetStreamPublisher struct {
+	js natsgo.JetStreamContext
+}
+
+func NewJetStreamPublisher(js natsgo.JetStreamContext) *JetStreamPublisher {
+	return &JetStreamPublisher{js: js}
+}
+
+func (p *JetStreamPublisher) Publish(ctx context.Context, subject string, data []byte) error {
+	msg := &natsgo.Msg{
+		Subject: subject,
+		Data:    data,
+		Header:  natsgo.Header{},
+	}
+	propagator.Inject(ctx, natsHeaderCarrier{header: msg.Header})
+	if _, err := p.js.PublishMsg(msg); err != nil {
+		return fmt.Errorf("js publish to %s: %w", subject, err)
+	}
+	return nil
+}

--- a/riddler/internal/infra/nats/streams.go
+++ b/riddler/internal/infra/nats/streams.go
@@ -1,0 +1,30 @@
+package nats
+
+import (
+	"errors"
+	"fmt"
+
+	natsgo "github.com/nats-io/nats.go"
+)
+
+const StreamGenerationRequested = "RIDDLER_GEN"
+
+// EnsureGenerationStream создаёт JetStream-стрим для субъекта riddler.generation.requested,
+// если он ещё не существует. Вызывается при старте Riddler, чтобы стрим был до первой публикации.
+func EnsureGenerationStream(js natsgo.JetStreamContext) error {
+	_, err := js.StreamInfo(StreamGenerationRequested)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, natsgo.ErrStreamNotFound) {
+		return fmt.Errorf("stream info: %w", err)
+	}
+	_, err = js.AddStream(&natsgo.StreamConfig{
+		Name:     StreamGenerationRequested,
+		Subjects: []string{SubjectGenerationRequested},
+	})
+	if err != nil {
+		return fmt.Errorf("add stream: %w", err)
+	}
+	return nil
+}

--- a/riddler/internal/worker/generation_requested_publisher.go
+++ b/riddler/internal/worker/generation_requested_publisher.go
@@ -28,12 +28,16 @@ type generationRequestedTaskRepository interface {
 	MarkFailed(ctx context.Context, id uuid.UUID, reason string, retryAfter time.Duration) error
 }
 
-type GenerationRequestedPublisher struct {
-	tasks     generationRequestedTaskRepository
-	publisher *natsinf.Publisher
+type generationNATSPublisher interface {
+	Publish(ctx context.Context, subject string, data []byte) error
 }
 
-func NewGenerationRequestedPublisher(tasks generationRequestedTaskRepository, publisher *natsinf.Publisher) *GenerationRequestedPublisher {
+type GenerationRequestedPublisher struct {
+	tasks     generationRequestedTaskRepository
+	publisher generationNATSPublisher
+}
+
+func NewGenerationRequestedPublisher(tasks generationRequestedTaskRepository, publisher generationNATSPublisher) *GenerationRequestedPublisher {
 	return &GenerationRequestedPublisher{tasks: tasks, publisher: publisher}
 }
 


### PR DESCRIPTION
## Проблема

Sphinx лежит → Riddler публикует `riddler.generation.requested` через Core NATS → сообщение теряется. Outbox при этом помечает задачу `done`, потому что `nc.PublishMsg` не возвращает ошибку при отсутствии подписчиков/стрима.

## Решение

1. **Riddler создаёт стрим `RIDDLER_GEN` при старте** (`EnsureGenerationStream`) — стрим гарантированно существует до первой публикации.
2. **`GenerationRequestedPublisher` переведён на `JetStreamPublisher`** (`js.PublishMsg`) — получает server-side ack о сохранении в стриме; при ошибке outbox ретраит задачу.
3. Когда Sphinx поднимается, durable consumer забирает все накопленные сообщения из стрима.

## Затронутые файлы

- `riddler/internal/infra/nats/publisher.go` — добавлен `JetStreamPublisher`
- `riddler/internal/infra/nats/streams.go` — новый файл, `EnsureGenerationStream`
- `riddler/internal/worker/generation_requested_publisher.go` — интерфейс вместо конкретного типа
- `riddler/internal/app/app.go` — инициализация JetStream, создание стрима, проброс `JetStreamPublisher`