### PR TITLE
fix: JetStream-доставка sphinx.generation.completed в Riddler

### DIFF
--- a/riddler/internal/app/app.go
+++ b/riddler/internal/app/app.go
@@ -68,6 +68,9 @@ func New(ctx context.Context, cfg *config.Config) (*App, error) {
 	if err := natsinf.EnsureGenerationStream(js); err != nil {
 		return nil, fmt.Errorf("ensure generation stream: %w", err)
 	}
+	if err := natsinf.EnsureGenerationCompletedStream(js); err != nil {
+		return nil, fmt.Errorf("ensure generation completed stream: %w", err)
+	}
 
 	jwksClient := jwks.NewClient(cfg.Doorman.JWKSEndpoint)
 	if err := jwksClient.Load(ctx); err != nil {
@@ -92,6 +95,7 @@ func New(ctx context.Context, cfg *config.Config) (*App, error) {
 	natsPublisher := natsinf.NewPublisher(natsConn)
 	natsJSPublisher := natsinf.NewJetStreamPublisher(js)
 	natsSubscriber := natsinf.NewSubscriber(natsConn)
+	natsJSSubscriber := natsinf.NewJetStreamSubscriber(js)
 
 	return &App{
 		quizHandler:    quizHandler,
@@ -104,7 +108,7 @@ func New(ctx context.Context, cfg *config.Config) (*App, error) {
 		attemptScoredPublisher:        worker.NewAttemptScoredPublisher(taskRepo, natsPublisher),
 
 		generationRequestedPublisher:  worker.NewGenerationRequestedPublisher(taskRepo, natsJSPublisher),
-		generationCompletedConsumer:   worker.NewGenerationCompletedConsumer(natsSubscriber, taskRepo),
+		generationCompletedConsumer:   worker.NewGenerationCompletedConsumer(natsJSSubscriber, taskRepo),
 		generationCompletedProcessor:  worker.NewGenerationCompletedProcessor(taskRepo, quizService),
 		courseSessionDeletedConsumer:  worker.NewCourseSessionDeletedConsumer(natsSubscriber, taskRepo),
 		courseSessionDeletedProcessor: worker.NewCourseSessionDeletedProcessor(taskRepo, sessionRepo),

--- a/riddler/internal/infra/nats/streams.go
+++ b/riddler/internal/infra/nats/streams.go
@@ -7,24 +7,33 @@ import (
 	natsgo "github.com/nats-io/nats.go"
 )
 
-const StreamGenerationRequested = "RIDDLER_GEN"
+const (
+	StreamGenerationRequested = "RIDDLER_GEN"
+	StreamGenerationCompleted = "SPHINX_GEN"
+)
 
-// EnsureGenerationStream создаёт JetStream-стрим для субъекта riddler.generation.requested,
-// если он ещё не существует. Вызывается при старте Riddler, чтобы стрим был до первой публикации.
 func EnsureGenerationStream(js natsgo.JetStreamContext) error {
-	_, err := js.StreamInfo(StreamGenerationRequested)
+	return ensureStream(js, StreamGenerationRequested, SubjectGenerationRequested)
+}
+
+func EnsureGenerationCompletedStream(js natsgo.JetStreamContext) error {
+	return ensureStream(js, StreamGenerationCompleted, SubjectGenerationCompleted)
+}
+
+func ensureStream(js natsgo.JetStreamContext, stream, subject string) error {
+	_, err := js.StreamInfo(stream)
 	if err == nil {
 		return nil
 	}
 	if !errors.Is(err, natsgo.ErrStreamNotFound) {
-		return fmt.Errorf("stream info: %w", err)
+		return fmt.Errorf("stream info %s: %w", stream, err)
 	}
 	_, err = js.AddStream(&natsgo.StreamConfig{
-		Name:     StreamGenerationRequested,
-		Subjects: []string{SubjectGenerationRequested},
+		Name:     stream,
+		Subjects: []string{subject},
 	})
 	if err != nil {
-		return fmt.Errorf("add stream: %w", err)
+		return fmt.Errorf("add stream %s: %w", stream, err)
 	}
 	return nil
 }

--- a/riddler/internal/infra/nats/subscriber.go
+++ b/riddler/internal/infra/nats/subscriber.go
@@ -32,3 +32,30 @@ func (s *Subscriber) QueueSubscribe(ctx context.Context, subject, queue string, 
 	<-ctx.Done()
 	return sub.Drain()
 }
+
+// JetStreamSubscriber подписывается через JetStream durable consumer.
+// Ack отправляется при успехе обработки, Nak — при ошибке (NATS переотправит).
+type JetStreamSubscriber struct {
+	js natsgo.JetStreamContext
+}
+
+func NewJetStreamSubscriber(js natsgo.JetStreamContext) *JetStreamSubscriber {
+	return &JetStreamSubscriber{js: js}
+}
+
+func (s *JetStreamSubscriber) Subscribe(ctx context.Context, subject, stream, consumer string, handler MsgHandler) error {
+	sub, err := s.js.Subscribe(subject, func(msg *natsgo.Msg) {
+		msgCtx := propagator.Extract(ctx, natsHeaderCarrier{header: msg.Header})
+		if err := handler(msgCtx, msg.Data); err != nil {
+			slog.ErrorContext(msgCtx, "ошибка обработки JS-сообщения", "subject", subject, "err", err)
+			_ = msg.Nak()
+			return
+		}
+		_ = msg.Ack()
+	}, natsgo.Durable(consumer), natsgo.ManualAck(), natsgo.BindStream(stream))
+	if err != nil {
+		return fmt.Errorf("js subscribe to %s: %w", subject, err)
+	}
+	<-ctx.Done()
+	return sub.Drain()
+}

--- a/riddler/internal/worker/generation_completed_consumer.go
+++ b/riddler/internal/worker/generation_completed_consumer.go
@@ -17,18 +17,26 @@ type generationCompletedScheduler interface {
 	Schedule(ctx context.Context, taskType domain.TaskType, payload []byte) error
 }
 
+const generationCompletedConsumer = "riddler-generation-completed"
+
 type GenerationCompletedConsumer struct {
-	subscriber *natsinf.Subscriber
+	subscriber *natsinf.JetStreamSubscriber
 	tasks      generationCompletedScheduler
 }
 
-func NewGenerationCompletedConsumer(subscriber *natsinf.Subscriber, tasks generationCompletedScheduler) *GenerationCompletedConsumer {
+func NewGenerationCompletedConsumer(subscriber *natsinf.JetStreamSubscriber, tasks generationCompletedScheduler) *GenerationCompletedConsumer {
 	return &GenerationCompletedConsumer{subscriber: subscriber, tasks: tasks}
 }
 
 func (c *GenerationCompletedConsumer) Run(ctx context.Context) error {
 	slog.Info("generation-completed-consumer: подписка", "subject", natsinf.SubjectGenerationCompleted)
-	return c.subscriber.QueueSubscribe(ctx, natsinf.SubjectGenerationCompleted, "riddler-generation-completed", c.handle)
+	return c.subscriber.Subscribe(
+		ctx,
+		natsinf.SubjectGenerationCompleted,
+		natsinf.StreamGenerationCompleted,
+		generationCompletedConsumer,
+		c.handle,
+	)
 }
 
 type generationCompletedMsg struct {

--- a/sphinx/app/worker/publisher.py
+++ b/sphinx/app/worker/publisher.py
@@ -25,7 +25,7 @@ class GenerationPublisher:
         pool: asyncpg.Pool,
         nc_test: Optional[nats.aio.client.Client] = None,
     ):
-        self._nc   = {"prod": nc_prod, "test": nc_test}
+        self._js   = {"prod": nc_prod.jetstream(), "test": nc_test.jetstream() if nc_test else None}
         self._pool = pool
 
     async def run(self) -> None:
@@ -58,8 +58,8 @@ class GenerationPublisher:
                 payload   = row["payload"]
                 env       = row["env"]
 
-                nc = self._nc.get(env)
-                if nc is None:
+                js = self._js.get(env)
+                if js is None:
                     logger.error(
                         "GenerationPublisher: no NATS connection for env=%s job_id=%s, skipping",
                         env, job_id,
@@ -67,7 +67,7 @@ class GenerationPublisher:
                     return
 
                 try:
-                    await nc.publish(SUBJECT, payload.encode())
+                    await js.publish(SUBJECT, payload.encode())
                 except Exception as e:
                     logger.error("GenerationPublisher: publish failed job_id=%s env=%s: %s", job_id, env, e)
                     return


### PR DESCRIPTION
## Проблема

Зеркальная к #123: Sphinx публиковал `sphinx.generation.completed` через Core NATS (`nc.publish`), Riddler подписывался через `QueueSubscribe`. Если Riddler лежал в момент публикации — результат генерации терялся, задача в outbox помечалась как done.

## Решение

1. **Riddler создаёт стрим `SPHINX_GEN`** при старте (`EnsureGenerationCompletedStream`) — стрим гарантированно существует до первой публикации Sphinx.
2. **`GenerationCompletedConsumer`** переведён на `JetStreamSubscriber` с durable consumer `riddler-generation-completed` — ack при успехе, nak при ошибке (NATS переотправит).
3. **Sphinx** переключён на `js.publish` — получает server-side ack; при ошибке не помечает `published_at` и outbox ретраит.

## Файлы

- `riddler/internal/infra/nats/streams.go` — добавлен `EnsureGenerationCompletedStream`, рефакторинг в `ensureStream`
- `riddler/internal/infra/nats/subscriber.go` — добавлен `JetStreamSubscriber`
- `riddler/internal/worker/generation_completed_consumer.go` — JetStream durable consumer
- `riddler/internal/app/app.go` — инициализация + проброс
- `sphinx/app/worker/publisher.py` — `js.publish` вместо `nc.publish`